### PR TITLE
Add github pages

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,31 @@
+name: static 
+on:
+  push:
+    branches:
+      - main
+
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
+      - uses: actions/cache@v3
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - run: pip install \
+          mkdocs-material \
+          mkdocs-include-dir-to-nav \
+          pymdown-extensions
+      - run: mkdocs gh-deploy --force

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://squidfunk.github.io/mkdocs-material/schema.json
+site_name: ghostincoolshell
+repo_name: ghostincoolshell/haoel-articles
+repo_url: https://github.com/ghostincoolshell/haoel-articles
+edit_uri: edit/main/docs/
+docs_dir: 'blogs'
+site_dir: 'docs'
+
+theme:
+  name: material
+
+nav:
+- Blog: 'rss2html2markdown/'
+
+plugins:
+  - search
+  - include_dir_to_nav
+
+markdown_extensions:
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.extra
+  - def_list


### PR DESCRIPTION
Closes #14 

This change will run an action to build static site and push it to branch `gh-pages`, the `pages` setting should set to this branch.

The project site will appear on https://ghostincoolshell.github.io/haoel-articles